### PR TITLE
Fixing missing step number on API < 28

### DIFF
--- a/stepper/src/main/java/com/aceinteract/android/stepper/menus/tab/TabNumberedStepperMenu.kt
+++ b/stepper/src/main/java/com/aceinteract/android/stepper/menus/tab/TabNumberedStepperMenu.kt
@@ -29,6 +29,7 @@ import androidx.core.view.isVisible
 import com.aceinteract.android.stepper.R
 import com.aceinteract.android.stepper.menus.base.StepperMenu
 import com.aceinteract.android.stepper.menus.base.StepperMenuItem
+import com.google.android.material.card.MaterialCardView
 import kotlin.math.max
 
 /**
@@ -66,6 +67,8 @@ class TabNumberedStepperMenu(
                     endToEnd = labelView.id
                     topToTop = this@TabNumberedStepperMenu.id
                 }
+
+                (this as MaterialCardView).radius = iconSizeInPX / 2f
             }
             val connectorView = item.connectorView?.apply {
                 setBackgroundColor(widgetColor)

--- a/stepper/src/main/res/layout/stepper_tab_item_number_icon.xml
+++ b/stepper/src/main/res/layout/stepper_tab_item_number_icon.xml
@@ -6,7 +6,7 @@
     android:layout_width="0dp"
     android:layout_height="0dp"
     app:cardBackgroundColor="@android:color/transparent"
-    app:cardCornerRadius="100dp"
+    app:cardCornerRadius="10dp"
     app:layout_constraintTop_toTopOf="parent"
     tools:layout_height="36dp"
     tools:layout_width="36dp">


### PR DESCRIPTION
Currently used card corner radius 100dp is for sure way to large. It looks like lower APIs do not process larger radii correctly. After some experiments 10dp appeared displayed correctly in the example app on devices with various APIs.

Should fix this issue https://github.com/acefalobi/android-stepper/issues/8